### PR TITLE
Rename variables for clarity, update default values

### DIFF
--- a/modules/ad-hoc/app/main.tf
+++ b/modules/ad-hoc/app/main.tf
@@ -151,12 +151,12 @@ module "default_celery_worker" {
   ecs_cluster_id     = module.ecs.cluster_id
   task_role_arn      = module.iam.task_role_arn
   execution_role_arn = module.iam.execution_role_arn
-  command            = var.default_celery_worker_command
+  command            = var.celery_worker_command
   env_vars           = concat(local.env_vars, var.extra_env_vars)
   image              = local.be_image
   region             = var.region
-  cpu                = var.default_celery_worker_cpu
-  memory             = var.default_celery_worker_memory
+  cpu                = var.celery_worker_cpu
+  memory             = var.celery_worker_memory
   private_subnet_ids = var.private_subnet_ids
 }
 

--- a/modules/ad-hoc/app/variables.tf
+++ b/modules/ad-hoc/app/variables.tf
@@ -131,19 +131,19 @@ variable "celery_beat_memory" {
 
 # default celery worker
 
-variable "default_celery_worker_command" {
+variable "celery_worker_command" {
   description = "Command used to start celery worker"
   default     = ["celery", "--app=backend.celery_app:app", "worker", "--loglevel=INFO", "-Q", "default"]
   type        = list(string)
 }
 
-variable "default_celery_worker_cpu" {
+variable "celery_worker_cpu" {
   default     = 1024
   description = "CPU to allocate to container"
   type        = number
 }
 
-variable "default_celery_worker_memory" {
+variable "celery_worker_memory" {
   default     = 2048
   description = "Amount (in MiB) of memory used by the task"
   type        = number

--- a/modules/prod/app/main.tf
+++ b/modules/prod/app/main.tf
@@ -69,12 +69,12 @@ module "api" {
   task_role_arn      = var.task_role_arn
   execution_role_arn = var.execution_role_arn
   app_sg_id          = var.app_sg_id
-  command            = var.api_command
+  command            = var.backend_command
   env_vars           = concat(local.env_vars, var.extra_env_vars)
   image              = local.be_image
   region             = var.region
-  cpu                = var.api_cpu
-  memory             = var.api_memory
+  cpu                = var.backend_cpu
+  memory             = var.backend_memory
   port               = 8000
   path_patterns      = ["/api/*", "/admin/*", "/graphql/*", "/mtv/*"]
   health_check_path  = "/api/health-check/"
@@ -107,8 +107,8 @@ module "web-ui" {
   env_vars           = []
   image              = local.fe_image
   region             = var.region
-  cpu                = var.api_cpu
-  memory             = var.api_memory
+  cpu                = var.backend_cpu
+  memory             = var.backend_memory
   port               = 80
   path_patterns      = ["/*"]
   health_check_path  = "/"
@@ -133,16 +133,16 @@ module "default_celery_worker" {
   ecs_cluster_id     = module.ecs.cluster_id
   task_role_arn      = var.task_role_arn
   execution_role_arn = var.execution_role_arn
-  command            = var.default_celery_worker_command
+  command            = var.celery_worker_command
   env_vars           = concat(local.env_vars, var.extra_env_vars)
   image              = local.be_image
   region             = var.region
-  cpu                = var.default_celery_worker_cpu
-  memory             = var.default_celery_worker_memory
+  cpu                = var.celery_worker_cpu
+  memory             = var.celery_worker_memory
   private_subnet_ids = var.private_subnet_ids
 }
 
-module "default_celery_worker_autoscaling" {
+module "celery_worker_autoscaling" {
   source       = "../../internal/autoscaling"
   cluster_name = "${terraform.workspace}-cluster"
   service_name = "${terraform.workspace}-default"

--- a/modules/prod/app/variables.tf
+++ b/modules/prod/app/variables.tf
@@ -104,21 +104,21 @@ variable "django_settings_module" {
 
 # api
 
-variable "api_command" {
+variable "backend_command" {
   description = "Command used to start backend API container"
   default     = ["gunicorn", "-t", "1000", "-b", "0.0.0.0:8000", "--log-level", "info", "backend.wsgi"]
   type        = list(string)
 }
 
-variable "api_cpu" {
+variable "backend_cpu" {
   default     = 1024
-  description = "CPU to allocate to container"
+  description = "CPU to allocate for this task (1024 = 1.0 vCPU)"
   type        = number
 }
 
-variable "api_memory" {
+variable "backend_memory" {
   default     = 2048
-  description = "Amount (in MiB) of memory used by the task"
+  description = "Amount (in MiB) of memory to allocate for this task"
   type        = number
 }
 
@@ -132,13 +132,13 @@ variable "frontend_command" {
 
 variable "frontend_cpu" {
   default     = 1024
-  description = "CPU to allocate to container for the frontend task"
+  description = "CPU to allocate for this task (1024 = 1.0 vCPU)"
   type        = number
 }
 
 variable "frontend_memory" {
   default     = 2048
-  description = "Amount (in MiB) of memory used by the frontend task"
+  description = "Amount (in MiB) of memory to allocate for this task"
   type        = number
 }
 
@@ -152,33 +152,33 @@ variable "celery_beat_command" {
 
 variable "celery_beat_cpu" {
   default     = 1024
-  description = "CPU to allocate to container"
+  description = "CPU to allocate for this task (1024 = 1.0 vCPU)"
   type        = number
 }
 
 variable "celery_beat_memory" {
   default     = 2048
-  description = "Amount (in MiB) of memory used by the task"
+  description = "Amount (in MiB) of memory to allocate for this task"
   type        = number
 }
 
-# default celery worker
+# Celery worker
 
-variable "default_celery_worker_command" {
+variable "celery_worker_command" {
   description = "Command used to start celery worker"
   default     = ["celery", "--app=backend.celery_app:app", "worker", "--loglevel=INFO", "-Q", "default"]
   type        = list(string)
 }
 
-variable "default_celery_worker_cpu" {
+variable "celery_worker_cpu" {
   default     = 1024
-  description = "CPU to allocate to container"
+  description = "CPU to allocate for this task (1024 = 1.0 vCPU)"
   type        = number
 }
 
-variable "default_celery_worker_memory" {
+variable "celery_worker_memory" {
   default     = 2048
-  description = "Amount (in MiB) of memory used by the task"
+  description = "Amount (in MiB) of memory to allocate for this task"
   type        = number
 }
 
@@ -192,12 +192,12 @@ variable "backend_update_command" {
 
 variable "backend_update_cpu" {
   default     = 1024
-  description = "CPU to allocate to container"
+  description = "CPU to allocate for this task (1024 = 1.0 vCPU)"
   type        = number
 }
 
 variable "backend_update_memory" {
   default     = 2048
-  description = "Amount (in MiB) of memory used by the task"
+  description = "Amount (in MiB) of memory to allocate for this task"
   type        = number
 }

--- a/modules/prod/app/variables.tf
+++ b/modules/prod/app/variables.tf
@@ -111,13 +111,13 @@ variable "backend_command" {
 }
 
 variable "backend_cpu" {
-  default     = 1024
-  description = "CPU to allocate for this task (1024 = 1.0 vCPU)"
+  default     = 256
+  description = "CPU to allocate for this task (256 = 0.25 vCPU)"
   type        = number
 }
 
 variable "backend_memory" {
-  default     = 2048
+  default     = 512
   description = "Amount (in MiB) of memory to allocate for this task"
   type        = number
 }
@@ -131,13 +131,13 @@ variable "frontend_command" {
 }
 
 variable "frontend_cpu" {
-  default     = 1024
-  description = "CPU to allocate for this task (1024 = 1.0 vCPU)"
+  default     = 256
+  description = "CPU to allocate for this task (256 = 0.25 vCPU)"
   type        = number
 }
 
 variable "frontend_memory" {
-  default     = 2048
+  default     = 512
   description = "Amount (in MiB) of memory to allocate for this task"
   type        = number
 }
@@ -151,13 +151,13 @@ variable "celery_beat_command" {
 }
 
 variable "celery_beat_cpu" {
-  default     = 1024
-  description = "CPU to allocate for this task (1024 = 1.0 vCPU)"
+  default     = 256
+  description = "CPU to allocate for this task (256 = 0.25 vCPU)"
   type        = number
 }
 
 variable "celery_beat_memory" {
-  default     = 2048
+  default     = 512
   description = "Amount (in MiB) of memory to allocate for this task"
   type        = number
 }
@@ -171,13 +171,13 @@ variable "celery_worker_command" {
 }
 
 variable "celery_worker_cpu" {
-  default     = 1024
-  description = "CPU to allocate for this task (1024 = 1.0 vCPU)"
+  default     = 256
+  description = "CPU to allocate for this task (256 = 0.25 vCPU)"
   type        = number
 }
 
 variable "celery_worker_memory" {
-  default     = 2048
+  default     = 512
   description = "Amount (in MiB) of memory to allocate for this task"
   type        = number
 }
@@ -191,13 +191,13 @@ variable "backend_update_command" {
 }
 
 variable "backend_update_cpu" {
-  default     = 1024
-  description = "CPU to allocate for this task (1024 = 1.0 vCPU)"
+  default     = 256
+  description = "CPU to allocate for this task (256 = 0.25 vCPU)"
   type        = number
 }
 
 variable "backend_update_memory" {
-  default     = 2048
+  default     = 512
   description = "Amount (in MiB) of memory to allocate for this task"
   type        = number
 }


### PR DESCRIPTION
This PR attempts to bring clarity with:

1. Rename `default_celery_worker_*` to `celery_worker_*` (since there is only 1 worker, this keeps things clear between celery_beat and celery_worker and avoids the confusion of variables like `default_celery_worker_memory`
2. Rename `api_*` to `backend_*` (memory, cpu, command)
3. Update variable description to be generic, but hopefully add more context

This PR also changes the lowers the memory and CPU allocated. 

As an aside, I've been running gunicorn with 0.01 vCPU (`10` CPU Units) and 512 MB memory and haven't had any issues! We don't need to go that low necessarily, but it's good to know how much we might need to set defaults.