### PR TITLE
fix: Give unique alarm_name to avoid collision when default and gunicorn both create the same alarm name.

### DIFF
--- a/modules/internal/autoscaling/main.tf
+++ b/modules/internal/autoscaling/main.tf
@@ -50,7 +50,7 @@ resource "aws_appautoscaling_policy" "down" {
 
 # CloudWatch alarm that triggers the autoscaling up policy
 resource "aws_cloudwatch_metric_alarm" "service_cpu_high" {
-  alarm_name          = "${terraform.workspace}_cpu_utilization_high"
+  alarm_name          = "${var.service_name}_cpu_utilization_high"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "2"
   metric_name         = "CPUUtilization"
@@ -69,7 +69,7 @@ resource "aws_cloudwatch_metric_alarm" "service_cpu_high" {
 
 # CloudWatch alarm that triggers the autoscaling down policy
 resource "aws_cloudwatch_metric_alarm" "service_cpu_low" {
-  alarm_name          = "${terraform.workspace}_cpu_utilization_low"
+  alarm_name          = "${var.service_name}_cpu_utilization_low"
   comparison_operator = "LessThanOrEqualToThreshold"
   evaluation_periods  = "2"
   metric_name         = "CPUUtilization"


### PR DESCRIPTION
Keeps this issue from happening:

```
 Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # module.main.module.celery_worker_autoscaling.aws_cloudwatch_metric_alarm.service_cpu_high will be updated in-place
  ~ resource "aws_cloudwatch_metric_alarm" "service_cpu_high" {
      ~ alarm_actions             = [
          ...
        ]
      ~ dimensions                = {
          ~ "ServiceName" = "staging-gunicorn" -> "staging-default"
            # (1 unchanged element hidden)
        }
        id                        = "staging_cpu_utilization_high"
        tags                      = {}
        # (15 unchanged attributes hidden)
    }

  # module.main.module.celery_worker_autoscaling.aws_cloudwatch_metric_alarm.service_cpu_low will be updated in-place
  ~ resource "aws_cloudwatch_metric_alarm" "service_cpu_low" {
      ~ alarm_actions             = [
          ...
        ]
      ~ dimensions                = {
          ~ "ServiceName" = "staging-gunicorn" -> "staging-default"
            # (1 unchanged element hidden)
        }
        id                        = "staging_cpu_utilization_low"
        tags                      = {}
        # (15 unchanged attributes hidden)
    }

Plan: 0 to add, 2 to change, 0 to destroy.
```